### PR TITLE
fix for missing type for v2 enptry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,16 @@
 		"logo.svg"
 	],
 	"exports": {
-		".": "./dist/prodia.js",
-		"./v2": "./dist/v2/index.js"
+		".": {
+      "import": "./dist/prodia.js",
+      "require": "./dist/prodia.js",
+      "types": "./dist/prodia.d.ts"
+    },
+    "./v2": {
+      "import": "./dist/v2/index.js",
+      "require": "./dist/v2/index.js",
+      "types": "./dist/v2/index.d.ts"
+    }
 	},
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
This solved the type issue "Cannot find module 'prodia/v2' or its corresponding type declarations"
when doing`import { createProdia } from "prodia/v2";` in a typescript file