### PR TITLE
`*`: expose entire multipart form response with `.form()`

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,7 +11,7 @@ jobs:
 
             - uses: denoland/setup-deno@v1
               with:
-                  deno-version: v2.x.x
+                  deno-version: v2.1.x
 
             - run: deno fmt --check
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
 			"devDependencies": {
 				"prettier": "^3.0.0",
 				"typescript": "^5.1.6"
+			},
+			"engines": {
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/prettier": {

--- a/v2/index.ts
+++ b/v2/index.ts
@@ -68,6 +68,9 @@ export type Prodia = {
 		// they will return the raw bytes for that output.
 		arrayBuffer: () => Promise<ArrayBuffer>;
 		uint8Array: () => Promise<Uint8Array>;
+
+		// get entire multipart form response
+		form: () => Promise<FormData>;
 	}>;
 };
 
@@ -230,6 +233,7 @@ export const createProdia = ({
 				new Uint8Array(
 					await (body.get("output") as Blob).arrayBuffer(),
 				),
+			form: () => Promise.resolve(body),
 		};
 	};
 


### PR DESCRIPTION
Exposes multipart form response directly which allows you the flexibility of accessing multiple files from the response in different ways e.g. by second "output" key or by `mask.png`.

Pegs Deno to `v2.1.x` for validation as unchanged parts of the file don't type check with newest `v2.2.x` version.