### PR TITLE
v2: expose price response from inference API

### DIFF
--- a/v2/index.ts
+++ b/v2/index.ts
@@ -29,6 +29,11 @@ export type ProdiaJob = {
 	config?: Record<string, JsonValue>;
 };
 
+export type ProdiaJobPrice = {
+	product: string;
+	dollars: number;
+};
+
 type ProdiaJobResult = ProdiaJob & {
 	id: string;
 	created_at: string;
@@ -38,6 +43,7 @@ type ProdiaJobResult = ProdiaJob & {
 		elapsed: number;
 		ips?: number;
 	};
+	price?: ProdiaJobPrice;
 };
 
 export type ProdiaJobOptions = {
@@ -49,6 +55,7 @@ export type ProdiaJobOptions = {
 		| "multipart/form-data"
 		| "video/mp4";
 	inputs?: (File | Blob | ArrayBuffer | Uint8Array)[];
+	price?: boolean;
 };
 
 const defaultJobOptions: ProdiaJobOptions = {
@@ -152,8 +159,12 @@ export const createProdia = ({
 			"job.json",
 		);
 
+		const jobUrl = options.price
+			? `${baseUrl}/job?price=true`
+			: `${baseUrl}/job`;
+
 		do {
-			response = await fetch(`${baseUrl}/job`, {
+			response = await fetch(jobUrl, {
 				method: "POST",
 				headers: {
 					Authorization: `Bearer ${token}`,


### PR DESCRIPTION
## Summary

- Adds opt-in `price: true` option to `ProdiaJobOptions` that passes `?price=true` query parameter to the inference API
- Adds `ProdiaJobPrice` type (`{ product: string; dollars: number }`) and optional `price` field on `ProdiaJobResult`
- No behavioral change unless `price: true` is explicitly passed

## Usage

```typescript
const result = await prodia.job(
  { type: "inference.flux.dev.txt2img.v1", config: { prompt: "a cat" } },
  { price: true },
);

console.log(result.job.price?.product); // "inference-flux-dev-txt2img-v1"
console.log(result.job.price?.dollars); // 0.05
```

## Test plan

- [ ] Verify `?price=true` query param is sent when option is set
- [ ] Verify price field is correctly parsed from job response
- [ ] Verify no query param is sent when option is omitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)